### PR TITLE
Validate MJSON configuration files and inheritance

### DIFF
--- a/data/model/messaging/message.mjson
+++ b/data/model/messaging/message.mjson
@@ -20,7 +20,7 @@
             "objectDescriptorModule": {
                 "%":"./message.mjson"
             },
-            "exportName": "MessagingChannel",
+            "exportName": "Message",
             "module": {
                 "%": "./message"
             },


### PR DESCRIPTION
Changed exportName from "MessagingChannel" to "Message" to match the descriptor name. This ensures consistency and prevents potential module loading issues.